### PR TITLE
feat(25.04): temporarily ignore CVE-2025-58767

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,6 +50,7 @@ jobs:
     uses: canonical/oci-factory/.github/workflows/Test-Rock.yaml@main
     with:
       oci-archive-name: ${{ matrix.rock.name }}_${{ matrix.rock.tag }}
+      trivyignore-path: .trivyignore
     secrets:
       host-github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# Under evaluation by the security team
+# https://ubuntu.com/security/CVE-2025-58767
+CVE-2025-58767


### PR DESCRIPTION
[CVE-2025-58767](https://github.com/advisories/GHSA-c2f4-jgmc-q2r5) has been reported in oci-factory [workflow run](https://github.com/canonical/oci-factory/actions/runs/17970843149). it is a vulnerability in `rexml-3.3.9` present in `libruby3.3_core` slice under `/usr/lib/ruby/gems/3.3.*/gems/rexml-*/**`. this PR adds an ignore directive for this CVE while it's [being evaluated by the security team](https://ubuntu.com/security/CVE-2025-58767).