### PR TITLE
feat: use `docker images`

### DIFF
--- a/ruby/3.3-25.04/spread.yaml
+++ b/ruby/3.3-25.04/spread.yaml
@@ -19,7 +19,7 @@ suites:
 
       # Wait for docker daemon to come online
       sudo apt install --yes retry
-      retry --times=10 --delay 2 -- docker run hello-world
+      retry --times=10 --delay 2 -- docker images
       sudo apt remove --yes retry
 
       # Load the rock into docker


### PR DESCRIPTION
using `docker run hello-world` can cause ['too many requests'](https://github.com/canonical/ruby-rock/actions/runs/17981407327/job/51148196738#step:5:2037) issues. this PR attempts to alleviate it.

```
:
2025-09-24 15:25:19.564 :: No VM guests are running outdated hypervisor (qemu) binaries on this host.
2025-09-24 15:25:19.564 :: + retry --times=10 --delay 2 -- docker run hello-world
2025-09-24 15:25:19.564 :: Unable to find image 'hello-world:latest' locally
2025-09-24 15:25:19.564 :: latest: Pulling from library/hello-world
2025-09-24 15:25:19.564 :: docker: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit.
2025-09-24 15:25:19.564 :: See 'docker run --help'.
2025-09-24 15:25:19.564 :: retry: docker returned 125, backing off for 2 seconds and trying again...
2025-09-24 15:25:19.564 :: Unable to find image 'hello-world:latest' locally
2025-09-24 15:25:19.564 :: docker: Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit.
2025-09-24 15:25:19.564 :: See 'docker run --help'.
2025-09-24 15:25:19.564 :: retry: docker returned 125, backing off for 2 seconds and trying again...
2025-09-24 15:25:19.564 :: Unable to find image 'hello-world:latest' locally
2025-09-24 15:25:19.564 :: docker: Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit.
2025-09-24 15:25:19.564 :: See 'docker run --help'.
2025-09-24 15:25:19.564 :: retry: docker returned 125, backing off for 2 seconds and trying again...
```