### PR TITLE
feat: ensure manifest order

### DIFF
--- a/ruby/3.3-25.04/rockcraft.yaml
+++ b/ruby/3.3-25.04/rockcraft.yaml
@@ -39,6 +39,7 @@ parts:
 
   deb-security-manifest:
     plugin: make
+    after: [ruby]
     source: https://github.com/canonical/rocks-security-manifest
     source-type: git
     source-branch: main


### PR DESCRIPTION
This PR ensures that the `deb-security-manifest` part runs after the `ruby` part. It so far always did, but like that the ordering is explicit.