### PR TITLE
feat: port trivyignore

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,6 +50,7 @@ jobs:
     uses: canonical/oci-factory/.github/workflows/Test-Rock.yaml@main
     with:
       oci-archive-name: ${{ matrix.rock.name }}_${{ matrix.rock.tag }}
+      trivyignore-path: .trivyignore
     secrets:
       host-github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# Upstream CVEs
+
+# net-imap: net-imap rubygem vulnerable to possible DoS by memory exhaustion
+# https://ubuntu.com/security/CVE-2025-43857
+CVE-2025-43857
+
+# WEBrick: HTTP request smuggling
+# https://ubuntu.com/security/CVE-2024-47220
+CVE-2024-47220
+
+# REXML DoS vulnerability when parsing XML containing multiple XML declarations
+# https://ubuntu.com/security/CVE-2025-58767
+CVE-2025-58767


### PR DESCRIPTION
port trivyignore from https://github.com/canonical/oci-factory/pull/627 to allow builds here to succeed. atm PRs here like, for example, #4 and #5 fail