### PR TITLE
feat: rename

### DIFF
--- a/ruby/3.3-25.04/spread.yaml
+++ b/ruby/3.3-25.04/spread.yaml
@@ -1,4 +1,4 @@
-project: my-rock-name
+project: ruby-rock
 
 backends:
   craft:
@@ -24,10 +24,10 @@ suites:
 
       # Load the rock into docker
       ROCK=$(ls $PROJECT_PATH/*.rock)
-      sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$ROCK" docker-daemon:my-rock-name:latest
+      sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$ROCK" docker-daemon:ruby-rock:latest
 
     restore: |
-      docker image rm --force my-rock-name:latest
+      docker image rm --force ruby-rock:latest
 
 exclude:
   - .git

--- a/ruby/3.3-25.04/spread/general/test/task.yaml
+++ b/ruby/3.3-25.04/spread/general/test/task.yaml
@@ -2,10 +2,10 @@ summary: test the 'ruby 3.3-25.04' project
 
 execute: |
   echo "Run Ruby smoke test"
-  docker run --rm -v $PWD:/rootfs my-rock-name:latest exec ruby /rootfs/ruby_smoke_test.rb
+  docker run --rm -v $PWD:/rootfs ruby-rock:latest exec ruby /rootfs/ruby_smoke_test.rb
 
-  docker run --rm -v $PWD:/rootfs my-rock-name:latest exec ruby /rootfs/net_telnet_test.rb
+  docker run --rm -v $PWD:/rootfs ruby-rock:latest exec ruby /rootfs/net_telnet_test.rb
 
-  docker run --rm -v $PWD:/rootfs my-rock-name:latest exec ruby /rootfs/ruby_webrick_test.rb
+  docker run --rm -v $PWD:/rootfs ruby-rock:latest exec ruby /rootfs/ruby_webrick_test.rb
 
-  docker run --rm -v $PWD:/rootfs my-rock-name:latest exec ruby /rootfs/ruby_xmlrpc_test.rb
+  docker run --rm -v $PWD:/rootfs ruby-rock:latest exec ruby /rootfs/ruby_xmlrpc_test.rb


### PR DESCRIPTION
tests were still using the `my-rock-name` name from the template